### PR TITLE
Commands to load reference data and reference links

### DIFF
--- a/src/service/reference-data.service.ts
+++ b/src/service/reference-data.service.ts
@@ -25,7 +25,10 @@ class ReferenceDataService extends RestService {
         // create reference data
         () => references
           .map((json: any) => templateService.template(json))
-          .map((json: any) => JSON.parse(json))
+          .map((json: any) => {
+            console.log('loading', json);
+            return JSON.parse(json);
+          })
           .map((data: any) => () => okapi.createReferenceData(data))
           .reduce((prevPromise, process) => prevPromise.then(() => process(), () => process()), Promise.resolve())
       ].reduce((prevPromise, process) => prevPromise.then(() => process(), () => process()), Promise.resolve());

--- a/src/service/reference-data.service.ts
+++ b/src/service/reference-data.service.ts
@@ -25,10 +25,7 @@ class ReferenceDataService extends RestService {
         // create reference data
         () => references
           .map((json: any) => templateService.template(json))
-          .map((json: any) => {
-            console.log('loading', json);
-            return JSON.parse(json);
-          })
+          .map((json: any) => JSON.parse(json))
           .map((data: any) => () => okapi.createReferenceData(data))
           .reduce((prevPromise, process) => prevPromise.then(() => process(), () => process()), Promise.resolve())
       ].reduce((prevPromise, process) => prevPromise.then(() => process(), () => process()), Promise.resolve());

--- a/src/service/reference-data.service.ts
+++ b/src/service/reference-data.service.ts
@@ -1,0 +1,40 @@
+import { RestService } from './rest.service';
+
+import { config } from '../config';
+import { fileService } from './file.service';
+import { templateService } from './template.service';
+import { okapi } from './okapi.service';
+
+class ReferenceDataService extends RestService {
+
+  public createReferenceData(name: string): Promise<any> {
+    const path = `${config.get('wd')}/${name}/referenceData`;
+    if (fileService.exists(path)) {
+      const references = fileService.readAll(path);
+      if (references.length === 0) {
+        return Promise.resolve();
+      }
+      return [
+        () => okapi.login(),
+        () => okapi.getUser(),
+        // clear reference data, iterate in reverse
+        () => references.slice().reverse()
+          .map((json: any) => JSON.parse(json))
+          .map((reference: any) => () => okapi.deleteReferenceData(reference))
+          .reduce((prevPromise, process) => prevPromise.then(() => process(), () => process()), Promise.resolve()),
+        // create reference data
+        () => references
+          .map((json: any) => templateService.template(json))
+          .map((json: any) => JSON.parse(json))
+          .map((data: any) => () => okapi.createReferenceData(data))
+          .reduce((prevPromise, process) => prevPromise.then(() => process(), () => process()), Promise.resolve())
+      ].reduce((prevPromise, process) => prevPromise.then(() => process(), () => process()), Promise.resolve());
+    }
+    return Promise.reject(`cannot find reference data at ${path}`);
+  }
+
+  // TODO: sort reference data by dependency to remove file name convention requirements
+
+}
+
+export const referenceData = new ReferenceDataService();

--- a/src/service/reference-links.service.ts
+++ b/src/service/reference-links.service.ts
@@ -12,10 +12,7 @@ class ReferenceLinksService extends RestService {
     if (fileService.exists(path)) {
       return fileService.readAll(path, '.json')
         .map((json: any) => templateService.template(json))
-        .map((json: any) => {
-          console.log('loading', json);
-          return JSON.parse(json);
-        })
+        .map((json: any) => JSON.parse(json))
         .map((data: any) => () => modExternalReferenceResolver.createReferenceLinkType(data))
         .reduce((prevPromise, process) => prevPromise.then(() => process(), () => process()), Promise.resolve());
     }

--- a/src/service/reference-links.service.ts
+++ b/src/service/reference-links.service.ts
@@ -1,0 +1,24 @@
+import { RestService } from './rest.service';
+
+import { config } from '../config';
+import { modExternalReferenceResolver } from './external-reference.service';
+import { fileService } from './file.service';
+import { templateService } from './template.service';
+
+class ReferenceLinksService extends RestService {
+
+  public createReferenceLinkTypes(name: string): Promise<any> {
+    const path = `${config.get('wd')}/${name}/referenceLinkTypes`;
+    if (fileService.exists(path)) {
+      return fileService.readAll(path, '.json')
+        .map((json: any) => templateService.template(json))
+        .map((json: any) => JSON.parse(json))
+        .map((data: any) => () => modExternalReferenceResolver.createReferenceLinkType(data))
+        .reduce((prevPromise, process) => prevPromise.then(() => process(), () => process()), Promise.resolve());
+    }
+    return Promise.reject(`cannot find reference link types at ${path}`);
+  }
+
+}
+
+export const referenceLinks = new ReferenceLinksService();

--- a/src/service/reference-links.service.ts
+++ b/src/service/reference-links.service.ts
@@ -12,7 +12,10 @@ class ReferenceLinksService extends RestService {
     if (fileService.exists(path)) {
       return fileService.readAll(path, '.json')
         .map((json: any) => templateService.template(json))
-        .map((json: any) => JSON.parse(json))
+        .map((json: any) => {
+          console.log('loading', json);
+          return JSON.parse(json);
+        })
         .map((data: any) => () => modExternalReferenceResolver.createReferenceLinkType(data))
         .reduce((prevPromise, process) => prevPromise.then(() => process(), () => process()), Promise.resolve());
     }

--- a/src/service/rest.service.ts
+++ b/src/service/rest.service.ts
@@ -20,6 +20,9 @@ export class RestService {
       }, (error: any, response: any, body: any) => {
         if (response && response.statusCode >= 200 && response.statusCode <= 299) {
           resolve(JSON.parse(body));
+        } else if (error) {
+          // console.log('failed get', url, error);
+          reject(error);
         } else {
           // console.log('failed get', url);
           reject(body);
@@ -41,6 +44,9 @@ export class RestService {
       }, (error: any, response: any, body: any) => {
         if (response && response.statusCode >= 200 && response.statusCode <= 299) {
           resolve(body);
+        } else if (error) {
+          console.log('failed post', url, error);
+          reject(error);
         } else {
           console.log('failed post', url, json);
           reject(body);
@@ -62,6 +68,9 @@ export class RestService {
       }, (error: any, response: any, body: any) => {
         if (response && response.statusCode >= 200 && response.statusCode <= 299) {
           resolve(body);
+        } else if (error) {
+          console.log('failed put', url, error);
+          reject(error);
         } else {
           console.log('failed put', url, json);
           reject(body);
@@ -83,6 +92,9 @@ export class RestService {
       }, (error: any, response: any, body: any) => {
         if (response && response.statusCode >= 200 && response.statusCode <= 299) {
           resolve(body);
+        } else if (error) {
+          // console.log('failed delete', url, error);
+          reject(error);
         } else {
           // console.log('failed delete', url);
           reject(body);


### PR DESCRIPTION
Resolves #15 
Resolves #17 
Resolves #18 
Relates to https://github.com/TAMULib/fm-workflows/pull/90

To load reference links:
```
fm load vendorReferenceLinks links
fm load userReferenceLinks links
fm load inventoryReferenceLinks links
```

To load reference data:
```
fm load vendors data
fm load users data
fm load bibs data
fm load holdings data
fm load items data
```